### PR TITLE
Add a check to see if room members are receiving keys from the captain

### DIFF
--- a/flute/flute.py
+++ b/flute/flute.py
@@ -171,6 +171,7 @@ def handle_key_transport_packet(packet_payload, parsed, server):
     # XXX careful not to double-add the captain in case of rekey
     flute_room.add_member(sender, captain_identity_pubkey, captain_transport_pubkey)
 
+    room.rekey_check_ok(channel, server)
     # Print some messages to the user
     buf = util.flute_channel_msg(flute_room.buf,
                                  "Got room key for %s from captain %s (friend name: %s)!" % (channel, sender, captain_friend_name))

--- a/weechat_flute.py
+++ b/weechat_flute.py
@@ -119,6 +119,15 @@ def rekey_timer_cb(data, remaining_calls):
     flute.rekey_room(data)
     return weechat.WEECHAT_RC_OK
 
+def rekey_check_timer_cb(data, remaining_calls):
+    splitted_data = data.split(',')
+    channel = splitted_data[0]
+    server = splitted_data[1]
+    buffr = weechat.buffer_search("irc", server + "." + channel)
+    msg = ("You haven't received a key for room %s in a while"
+                         ", something fishy might be happening!!") % channel
+    weechat.prnt(buffr, otrlib.colorize(msg, "red"))
+    return weechat.WEECHAT_RC_OK
 ################################################################################
 
 # Register the plugin with Weechat.


### PR DESCRIPTION
I added a timer that checks periodically if we are still receiving messages from the captain.

Specifically it has a period of 2 minutes more than the rekeying period. If in the mean time we have received a key transport from the captain the timer is unhooked and nothing happens. If we havent then the still hooked timer triggers and a message is printed in the channels buffer informing the user that something has gone wrong.
